### PR TITLE
Cross website tracking for the sync plugin to refer Google credentials

### DIFF
--- a/IITC-Mobile/Info.plist
+++ b/IITC-Mobile/Info.plist
@@ -78,6 +78,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Some plugins need to store Google credentials so that you do not have to authenticate every time you launch IITC.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>IITC requires access to location service to display your location and orientation on map.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
The cross website tracking should be allowed to keep Google authentication for sync plugin over relaunching IITC-Mobile app.
This modification add the Allow Cross-Website Tacking switch on the IITC-Mobile in the settings app.
After the switch is turned on, the Google authentication for sync plugin will be kept over re-launching IITC-Mobile app.

Note:
This could cause a risk of allowing malicious plugins to steal personal information.

This is for the issue #7.